### PR TITLE
Add Node.js Express server alongside Python server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,13 @@ services:
       - 8000:8000
     volumes:
       - ./python-server/src:/app/src
+
+  node-server:
+    build:
+      context: ./node-server
+      dockerfile: Dockerfile
+    ports:
+      - 8001:8001
+    volumes:
+      - ./node-server:/app
+      - /app/node_modules

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN yarn install
+
+COPY . .
+
+EXPOSE 8001
+
+CMD ["yarn", "start"]

--- a/node-server/package.json
+++ b/node-server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-server",
+  "version": "1.0.0",
+  "description": "Simple Express server",
+  "main": "server.js",
+  "scripts": {
+    "start": "nodemon server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/node-server/server.js
+++ b/node-server/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = 8001;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Node.js Express server is running!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Overview
This PR adds a new Node.js Express server to run alongside the existing Python FastAPI server as part of the migration process.

## Changes Made
- ✅ Created  folder with Express.js server
- ✅ Added  with Express and Nodemon dependencies
- ✅ Created  with basic Express server listening on port 8001
- ✅ Added  for containerizing the Node.js server
- ✅ Updated  to run both servers simultaneously
  - Python server: port 8000
  - Node.js server: port 8001

## Testing
Both servers are now running successfully:
- Python server: http://localhost:8000 (FastAPI with /tasks endpoint)
- Node.js server: http://localhost:8001 (Express with basic endpoint)

## Next Steps
- Migrate the /tasks endpoints from Python to Node.js
- Update documentation
- Eventually deprecate the Python server

This sets up the foundation for the Python-to-Node.js migration process.